### PR TITLE
add string formatter to `text`

### DIFF
--- a/src/DearImGui.hs
+++ b/src/DearImGui.hs
@@ -293,7 +293,7 @@ sameLine = liftIO do
 text :: MonadIO m => String -> m ()
 text t = liftIO do
   withCString t \textPtr ->
-    [C.exp| void { Text($(char* textPtr)) } |]
+    [C.exp| void { Text("%s", $(char* textPtr)) } |]
 
 
 -- | A button. Returns 'True' when clicked.


### PR DESCRIPTION
fixes compilation error on darwin