### PR TITLE
Fix conditional in cabal file

### DIFF
--- a/dear-imgui.cabal
+++ b/dear-imgui.cabal
@@ -56,11 +56,13 @@ library
     if os(windows)
       extra-libraries:
         opengl32
-    if os(darwin)
-      frameworks: OpenGL
     else
-      extra-libraries:
-        GL
+      if os(darwin)
+        frameworks:
+          OpenGL
+      else
+        extra-libraries:
+          GL
 
   if flag(sdl)
     exposed-modules:


### PR DESCRIPTION
The if conditionals were incorrectly nested, which caused a problem with OpenGL on Windows.