### PR TITLE
Ignore imgui.ini

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ cabal.project.local
 cabal.project.local~
 .HTF/
 .ghc.environment.*
+/imgui.ini


### PR DESCRIPTION
This file gets generated by routine testing but we'll never want to commit it.