### PR TITLE
Define types for use in ImGui Context

### DIFF
--- a/src/DearImGui/Context.hs
+++ b/src/DearImGui/Context.hs
@@ -18,16 +18,20 @@ import Language.C.Types
   ( pattern TypeName )
 
 -- dear-imgui
+import DearImGui.Enums
 import DearImGui.Structs
-  ( ImVec2, ImVec3, ImVec4 )
 
 --------------------------------------------------------------------------------
 
 imguiContext :: Context
 imguiContext = mempty
   { ctxTypesTable = Map.fromList
-      [ ( TypeName "ImVec2", [t| ImVec2 |] )
-      , ( TypeName "ImVec3", [t| ImVec3 |] )
-      , ( TypeName "ImVec4", [t| ImVec4 |] )
+      [ ( TypeName "ImGuiCol"  , [t| ImGuiCol |] )
+      , ( TypeName "ImGuiCond" , [t| ImGuiCond |] )
+      , ( TypeName "ImGuiDir"  , [t| ImGuiDir |] )
+      , ( TypeName "ImGuiStyleVar", [t| ImGuiStyleVar |] )
+      , ( TypeName "ImVec2"    , [t| ImVec2 |] )
+      , ( TypeName "ImVec3"    , [t| ImVec3 |] )
+      , ( TypeName "ImVec4"    , [t| ImVec4 |] )
       ]
   }


### PR DESCRIPTION
Just doing a little cleanup:

- some functions were not exported,
- some functions were missing the initial `|` for their documentation,
- add types to the ImGui Context instead of coercing to `int`. This is more robust, in case upstream changes any of the larger enums to be `64` bits instead of `32` for instance.