### PR TITLE
Allow building of OpenGL3 component on Windows

### DIFF
--- a/dear-imgui.cabal
+++ b/dear-imgui.cabal
@@ -97,16 +97,8 @@ library
       DearImGui.OpenGL3
     cxx-sources:
       imgui/backends/imgui_impl_opengl3.cpp
-    if os(windows)
-      buildable:
-        False
-    else
-      if os(darwin)
-        buildable:
-          False
-      else
-        pkgconfig-depends:
-          glew
+    pkgconfig-depends:
+      glew
 
   if flag(vulkan)
     exposed-modules:


### PR DESCRIPTION
This works for me on Windows. I haven't tested on macOS but we might as well leave it like this rather than `unbuildable` until we learn otherwise.