### PR TITLE
Handle remaining enums

### DIFF
--- a/dear-imgui.cabal
+++ b/dear-imgui.cabal
@@ -183,10 +183,14 @@ library dear-imgui-generator
   build-depends:
       template-haskell
         >= 2.15 && < 2.19
+    , containers
+       ^>= 0.6.2.1
     , directory
         >= 1.3 && < 1.4
     , filepath
         >= 1.4 && < 1.5
+    , inline-c
+        >= 0.9.0.0 && < 0.10
     , megaparsec
         >= 9.0 && < 9.1
     , parser-combinators

--- a/generator/DearImGui/Generator/Types.hs
+++ b/generator/DearImGui/Generator/Types.hs
@@ -1,19 +1,27 @@
 {-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE BlockArguments #-}
 {-# LANGUAGE DeriveLift #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE TemplateHaskellQuotes #-}
 
 module DearImGui.Generator.Types where
 
+-- base
+import Data.Traversable
+  ( for )
+
 -- template-haskell
+import qualified Language.Haskell.TH        as TH
 import qualified Language.Haskell.TH.Syntax as TH
-  ( Lift(..), Name(..) )
 
 -- text
 import Data.Text
   ( Text )
+import qualified Data.Text as Text
+  ( unpack )
 
 -- th-lift
 import Language.Haskell.TH.Lift
@@ -25,18 +33,30 @@ newtype Comment = CommentText { commentText :: Text }
   deriving stock   ( Show, TH.Lift )
   deriving newtype ( Eq, Ord )
 
-data Enumeration
+data Enumeration typeName
   = Enumeration
   { docs             :: ![Comment]
   , enumName         :: !Text
+  , enumTypeName     :: !typeName
   , enumSize         :: !Integer
-  , enumType         :: !TH.Name
+  , underlyingType   :: !TH.Name
   , hasExplicitCount :: !Bool
   , patterns         :: [ ( Text, Integer, Comment ) ]
   }
   deriving stock ( Show, TH.Lift )
 
-data Headers
+data Headers typeName
   = Headers
-  { enums :: [ Enumeration ] }
+  { enums :: [ Enumeration typeName ] }
   deriving stock ( Show, TH.Lift )
+
+generateNames :: Headers () -> TH.Q ( Headers ( TH.Name, TH.Name ) )
+generateNames ( Headers { enums = basicEnums } ) = do
+  enums <- for basicEnums \ enum@( Enumeration { enumName } ) -> do
+    let
+      enumNameStr :: String
+      enumNameStr = Text.unpack enumName
+    tyName  <- TH.newName enumNameStr
+    conName <- TH.newName enumNameStr
+    pure $ enum { enumTypeName = ( tyName, conName ) }
+  pure $ Headers { enums }

--- a/src/DearImGui/Context.hs
+++ b/src/DearImGui/Context.hs
@@ -18,21 +18,19 @@ import Language.C.Types
   ( pattern TypeName )
 
 -- dear-imgui
-import DearImGui.Enums
 import DearImGui.Structs
+
+-- dear-imgui-generator
+import DearImGui.Generator
+  ( enumerationsTypesTable )
 
 --------------------------------------------------------------------------------
 
 imguiContext :: Context
 imguiContext = mempty
-  { ctxTypesTable = Map.fromList
-      [ ( TypeName "ImGuiCol" , [t| ImGuiCol |] )
-      , ( TypeName "ImGuiCond", [t| ImGuiCond |] )
-      , ( TypeName "ImGuiDir" , [t| ImGuiDir |] )
-      , ( TypeName "ImGuiStyleVar"    , [t| ImGuiStyleVar |] )
-      , ( TypeName "ImGuiTabBarFlags" , [t| ImGuiTabBarFlags |] )
-      , ( TypeName "ImGuiTabItemFlags", [t| ImGuiTabItemFlags |] )
-      , ( TypeName "ImVec2", [t| ImVec2 |] )
+  { ctxTypesTable = enumerationsTypesTable <>
+    Map.fromList
+      [ ( TypeName "ImVec2", [t| ImVec2 |] )
       , ( TypeName "ImVec3", [t| ImVec3 |] )
       , ( TypeName "ImVec4", [t| ImVec4 |] )
       ]


### PR DESCRIPTION
This handles the remaining enum types in the headers that aren't in the enums section.    

It also automatically handles adding all the enumerations to the `inline-c` context types table, and a small improvement to the display of parse error messages.