### PR TITLE
Generator: use mkName instead of newName

### DIFF
--- a/generator/DearImGui/Generator.hs
+++ b/generator/DearImGui/Generator.hs
@@ -92,7 +92,7 @@ headers = $( do
           ( unlines ( map Megaparsec.parseErrorPretty . toList $ Megaparsec.bundleErrors err ) ) <> "\n" <>
           ( unlines ( map show prev ) <> "\n\n" <> unlines ( map show rest ) )
       Right res -> pure res
-  TH.lift =<< generateNames basicHeaders
+  TH.lift $ generateNames basicHeaders
   )
 
 --------------------------------------------------------------------------------


### PR DESCRIPTION
I have no idea why the version with `newName` caused the issue experienced by falling-edge, but this fixes it.