### PR TITLE
Begin child with size param

### DIFF
--- a/src/DearImGui.hs
+++ b/src/DearImGui.hs
@@ -52,6 +52,7 @@ module DearImGui
 
     -- * Child Windows
   , beginChild
+  , beginChildOfSize
   , endChild
 
     -- * Parameter stacks
@@ -343,6 +344,15 @@ beginChild :: MonadIO m => String -> m Bool
 beginChild name = liftIO do
   withCString name \namePtr ->
     (0 /=) <$> [C.exp| bool { ImGui::BeginChild($(char* namePtr)) } |]
+
+
+-- | Wraps @ImGui::BeginChild()@ with size param.
+beginChildOfSize :: (MonadIO m, HasGetter ref ImVec2) => String -> ref -> m Bool
+beginChildOfSize name sizeRef = liftIO do
+  size <- get sizeRef
+  withCString name \namePtr ->
+    with size $ \sizePtr ->
+      (0 /=) <$> [C.exp| bool { ImGui::BeginChild($(char* namePtr), *$(ImVec2 *sizePtr)) } |]
 
 
 -- | Wraps @ImGui::EndChild()@.


### PR DESCRIPTION
**Not ready to merge yet, but issue can be discussed.**

This is either a pull request or an issue. The current bindings to functions like `ImGui::BeginChild` doesn't cover optional params. When working on my app, I needed to set a child window's size, which is such an optional param. I tried to modify `beginChild` in place to take more params, but that broke some example build targets, since they didn't supply enough params to the new `beginChild`.

So I think the options are:
1. Modify functions like `beginChild` in place, and fix the code for example build targets.
2. Create a new function named like `beginChildOfSize` or `beginChildWithOptParams`, which is what this branch is currently doing.