### PR TITLE
Disable build-depends when not building executables

### DIFF
--- a/dear-imgui.cabal
+++ b/dear-imgui.cabal
@@ -210,19 +210,21 @@ executable test
   import: common
   main-is: Main.hs
   default-language: Haskell2010
-  build-depends: base, sdl2, gl, dear-imgui
   ghc-options: -Wall
   if (!flag(examples) || !flag(sdl) || !flag(opengl2))
     buildable: False
+  else
+    build-depends: base, sdl2, gl, dear-imgui
 
 executable glfw
   main-is: Main.hs
   hs-source-dirs: examples/glfw
   default-language: Haskell2010
-  build-depends: base, GLFW-b, gl, dear-imgui, managed
   ghc-options: -Wall
   if (!flag(examples) || !flag(glfw) || !flag(opengl2))
     buildable: False
+  else
+    build-depends: base, GLFW-b, gl, dear-imgui, managed
 
 executable readme
   import: common
@@ -238,32 +240,33 @@ executable vulkan
   other-modules: Attachments, Backend, Input, Util
   hs-source-dirs: examples/vulkan
   default-language: Haskell2010
-  build-depends:
-      dear-imgui
-    , bytestring
-        >= 0.10.10.0 && < 0.12
-    , containers
-       ^>= 0.6.2.1
-    , logging-effect
-       ^>= 1.3.12
-    , resourcet
-       ^>= 1.2.4.2
-    , sdl2
-       ^>= 2.5.3.0
-    , text-short
-       ^>= 0.1.3
-    , transformers
-       ^>= 0.5.6.2
-    , unliftio
-        >= 0.2.13 && < 0.2.15
-    , unliftio-core
-       ^>= 0.2.0.1
-    , vector
-       ^>= 0.12.1.2
-    , vulkan
-       ^>= 3.9
-    , vulkan-utils
-       ^>= 0.4.1
   ghc-options: -Wall
   if (!flag(examples) || !flag(sdl) || !flag(vulkan))
     buildable: False
+  else
+    build-depends:
+        dear-imgui
+      , bytestring
+          >= 0.10.10.0 && < 0.12
+      , containers
+         ^>= 0.6.2.1
+      , logging-effect
+         ^>= 1.3.12
+      , resourcet
+         ^>= 1.2.4.2
+      , sdl2
+         ^>= 2.5.3.0
+      , text-short
+         ^>= 0.1.3
+      , transformers
+         ^>= 0.5.6.2
+      , unliftio
+          >= 0.2.13 && < 0.2.15
+      , unliftio-core
+         ^>= 0.2.0.1
+      , vector
+         ^>= 0.12.1.2
+      , vulkan
+         ^>= 3.9
+      , vulkan-utils
+         ^>= 0.4.1


### PR DESCRIPTION
This change follows up on https://github.com/haskell-game/dear-imgui.hs/pull/41
where it seems like cabal still need the examples dependency even when they are
not buildable, e.g.: `next goal: vulkan-utils (dependency of dear-imgui)` with
cabal-install version 3.2.0.0.