### PR TITLE
Update generator for GHC 9.2

### DIFF
--- a/generator/DearImGui/Generator.hs
+++ b/generator/DearImGui/Generator.hs
@@ -135,13 +135,13 @@ declareEnumeration finiteEnumName countName ( Enumeration {..} ) = do
     derivClause = TH.derivClause ( Just TH.NewtypeStrategy ) classes
 
   newtypeDecl <-
-#if MIN_VERSION_base(4,16,0)
+#if MIN_VERSION_template_haskell(2,18,0)
     ( if   null docs
       then TH.newtypeD
       else
         \ ctx name bndrs kd con derivs ->
-          TH.newtypeD_doc ctx name ( fmap pure bndrs ) ( fmap pure kd ) ( con, "", [] ) derivs
-            ( Text.unpack . Text.unlines . coerce $ docs )
+          TH.newtypeD_doc ctx name ( fmap pure bndrs ) ( fmap pure kd ) ( con, Nothing, [] ) derivs
+            ( Just . Text.unpack . Text.unlines . coerce $ docs )
     )
 #else
     TH.newtypeD
@@ -168,13 +168,13 @@ declareEnumeration finiteEnumName countName ( Enumeration {..} ) = do
     patName   <- TH.newName patNameStr
     patSynSig <- TH.patSynSigD patName ( TH.conT tyName )
     pat       <-
-#if MIN_VERSION_base(4,16,0)
+#if MIN_VERSION_template_haskell(2,18,0)
       ( if   Text.null patDoc
         then TH.patSynD
         else
           \ nm args dir pat ->
           TH.patSynD_doc nm args dir pat
-            ( Text.unpack patDoc ) []
+            ( Just $ Text.unpack patDoc ) []
       )
 #else
       TH.patSynD

--- a/generator/DearImGui/Generator/Parser.hs
+++ b/generator/DearImGui/Generator/Parser.hs
@@ -243,11 +243,11 @@ patternNameAndValue
 patternNameAndValue enumName =
   try do
       sz <- count
-      modify' ( ( \ st -> st { enumSize = sz, hasExplicitCount = True } ) :: EnumState -> EnumState )
+      modify' ( \ ( EnumState {..} ) -> EnumState { enumSize = sz, hasExplicitCount = True, .. } )
       pure Nothing
   <|> do
         pat@( _, val ) <- value
-        modify' ( \ st -> st { enumSize = ( enumSize :: EnumState -> Integer ) st + 1, currEnumTag = val + 1} )
+        modify' ( \ ( EnumState {..} ) -> EnumState { enumSize = enumSize + 1, currEnumTag = val + 1, .. } )
         pure ( Just pat )
   where
     count :: StateT EnumState m Integer


### PR DESCRIPTION
This contains two small changes for GHC 9.2:

1. Update the Template Haskell part of the generator which adds the docstrings, to adapt for some changes in the `putDoc` API that is part of GHC 9.2.
2. Address some warnings involving duplicate record fields.