### PR TITLE
Add wantCaptureMouse, wantCaptureKeyboard

### DIFF
--- a/src/DearImGui.hs
+++ b/src/DearImGui.hs
@@ -187,6 +187,8 @@ module DearImGui
 
     -- * Item/Widgets Utilities
   , Raw.isItemHovered
+  , Raw.wantCaptureMouse
+  , Raw.wantCaptureKeyboard
 
     -- * Types
   , module DearImGui.Enums

--- a/src/DearImGui/Raw.hs
+++ b/src/DearImGui/Raw.hs
@@ -156,6 +156,8 @@ module DearImGui.Raw
 
     -- * Item/Widgets Utilities
   , isItemHovered
+  , wantCaptureMouse
+  , wantCaptureKeyboard
 
     -- * Types
   , module DearImGui.Enums
@@ -873,3 +875,11 @@ pushStyleVar style valPtr = liftIO do
 popStyleVar :: (MonadIO m) => CInt -> m ()
 popStyleVar n = liftIO do
   [C.exp| void { PopStyleVar($(int n)) } |]
+
+wantCaptureMouse :: MonadIO m => m Bool
+wantCaptureMouse = liftIO do
+  (0 /=) <$> [C.exp| bool { GetIO().WantCaptureMouse } |]
+
+wantCaptureKeyboard :: MonadIO m => m Bool
+wantCaptureKeyboard = liftIO do
+  (0 /=) <$> [C.exp| bool { GetIO().WantCaptureKeyboard } |]


### PR DESCRIPTION
Required for skipping input events in app areas occluded and, presumably, handled by DearImGui.