### PR TITLE
Add a lower-bound on `inline-c`

### DIFF
--- a/dear-imgui.cabal
+++ b/dear-imgui.cabal
@@ -112,7 +112,7 @@ library
       dear-imgui-generator
     , containers
     , managed
-    , inline-c
+    , inline-c >= 0.9
     , inline-c-cpp
     , StateVar
     , unliftio


### PR DESCRIPTION
The `bool` type is only in 0.9 onwards.