### PR TITLE
Add remaining BeginChild arguments as required

### DIFF
--- a/Main.hs
+++ b/Main.hs
@@ -120,7 +120,7 @@ loop window checked color slider r pos size' selected tab1Ref tab2Ref = do
 
   progressBar 0.314 (Just "Pi")
 
-  beginChild "Child"
+  beginChild "Child" (ImVec2 0 0) True ImGuiWindowFlags_None
 
   beginCombo "Label" "Preview" >>= whenTrue do
     selectable "Testing 1"


### PR DESCRIPTION
Old behaviour with all default arguments is a special case to run
some action scoped to a different child window.

This now handled by `beginChildContext`/`withChildContext`.