### PR TITLE
Nix upgrades

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -4,12 +4,12 @@ haskellNix ? (import (import ./nix/sources.nix)."haskell.nix" { })
 # haskell.nix provides access to the nixpkgs pins which are used by our CI,
 # hence you will be more likely to get cache hits when using these.
 # But you can also just use your own, e.g. '<nixpkgs>'.
-, nixpkgsSrc ? haskellNix.sources.nixpkgs-2009
+, nixpkgsSrc ? haskellNix.sources.nixpkgs-2105
 
   # haskell.nix provides some arguments to be passed to nixpkgs, including some
   # patches and also the haskell.nix functionality itself as an overlay.
 , nixpkgsArgs ? haskellNix.nixpkgsArgs
-, compiler-nix-name ? "ghc884"
+, compiler-nix-name ? "ghc8107"
 }:
 let
   pkgs = import nixpkgsSrc nixpkgsArgs;


### PR DESCRIPTION
Switches the default Nix build to use GHC 8.10.7 and NixOS 21.05