### PR TITLE
added shared-lib for downstream

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -2,3 +2,5 @@ packages: *.cabal
 package dear-imgui
   flags: +sdl2 +glfw +opengl2 +opengl3 +vulkan +examples
   ghc-options: -Wall -Wcompat -fno-warn-unused-do-bind
+
+shared: true

--- a/dear-imgui.cabal
+++ b/dear-imgui.cabal
@@ -151,13 +151,20 @@ library
     DearImGui.Context
     DearImGui.Enums
     DearImGui.Structs
-  cxx-options: -std=c++11
+  cxx-options:
+    -std=c++11
   cxx-sources:
     imgui/imgui.cpp
     imgui/imgui_demo.cpp
     imgui/imgui_draw.cpp
     imgui/imgui_tables.cpp
     imgui/imgui_widgets.cpp
+  install-includes:
+    imgui.h
+    imgui_internal.h
+    imstb_rectpack.h
+    imstb_textedit.h
+    imstb_truetype.h
   extra-libraries:
     stdc++
   include-dirs:


### PR DESCRIPTION
This exposes the generated .so-file & the headers for downstream usage (i.e. implot).