### PR TITLE
added flag_ImDrawIdx

### DIFF
--- a/dear-imgui.cabal
+++ b/dear-imgui.cabal
@@ -126,6 +126,17 @@ flag use-wchar32
   manual:
     True
 
+flag use-ImDrawIdx32
+  description:
+    Use 32-bit vertex indices (default is 16-bit) is one way to allow large meshes with more than 64K vertices.
+    Your renderer backend will need to support it (most example renderer backends support both 16/32-bit indices).
+    Another way to allow large meshes while keeping 16-bit indices is to handle ImDrawCmd::VtxOffset in your renderer.
+    Read about ImGuiBackendFlags_RendererHasVtxOffset for details.
+  default:
+    True
+  manual:
+    True
+
 common common
   build-depends:
       base
@@ -180,6 +191,10 @@ library
   if flag(use-wchar32)
     cxx-options: -DIMGUI_USE_WCHAR32
     cpp-options: -DIMGUI_USE_WCHAR32
+
+  if flag(use-ImDrawIdx32)
+    cxx-options: "-DImDrawIdx=unsigned int"
+    cpp-options: "-DImDrawIdx=unsigned int"
 
   if flag(opengl2)
     exposed-modules:


### PR DESCRIPTION
Exposed the "#define ImDrawIdx unsigned int" from the imconfig.h for external configuration.

It is needed when you want to draw "more" vertices in an object (as i need with the implot-extension) without resorting to (inefficient) hacks with offsets etc. for the expense of a bit of memory-bloat in the indexes.

Similar tradeoffs to the WCHAR32-flag already present of using 32 instead of 16 bits.