### PR TITLE
Fix compilation on MacOS / GHC 8.10.7

### DIFF
--- a/dear-imgui.cabal
+++ b/dear-imgui.cabal
@@ -185,6 +185,10 @@ library
     , vector
     , text
 
+  if os(darwin)
+    ghc-options:
+      -optcxx-std=c++11
+
   if flag(disable-obsolete)
     cxx-options: -DIMGUI_DISABLE_OBSOLETE_FUNCTIONS
 


### PR DESCRIPTION
Fixes errors along the lines of:
dear-imgui  > [ 2 of 17] Compiling DearImGui.GLFW
dear-imgui  > error: unknown type name 'constexpr'

So the "-std=c++11" option is not being passed to the C++ compiler on MacOS 12.5.1 (GHC 8.10.7, Stack 2.7.5, Cabal 3.6.2.0).
The issue seems potentially related to https://github.com/haskell/cabal/issues/6421
Doesn't seem like this should be necessary with newer versions of Cabal, but nevertheless, this fix is needed and 'works for me'.

May be worth revisiting in the future.

Closes #155 