### PR TITLE
Expose DearImGui.Raw.Context

### DIFF
--- a/dear-imgui.cabal
+++ b/dear-imgui.cabal
@@ -159,8 +159,8 @@ library
     DearImGui.Raw.Font.GlyphRanges
     DearImGui.Raw.IO
     DearImGui.Raw.ListClipper
+    DearImGui.Raw.Context
   other-modules:
-    DearImGui.Context
     DearImGui.Enums
     DearImGui.Structs
   cxx-options: -std=c++11

--- a/src/DearImGui/Raw.hs
+++ b/src/DearImGui/Raw.hs
@@ -264,7 +264,7 @@ import System.IO.Unsafe
   ( unsafePerformIO )
 
 -- dear-imgui
-import DearImGui.Context
+import DearImGui.Raw.Context
   ( imguiContext )
 import DearImGui.Enums
 import DearImGui.Structs

--- a/src/DearImGui/Raw/Context.hs
+++ b/src/DearImGui/Raw/Context.hs
@@ -6,7 +6,7 @@
 {-# language PatternSynonyms #-}
 {-# language TemplateHaskell #-}
 
-module DearImGui.Context where
+module DearImGui.Raw.Context where
 
 -- containers
 import qualified Data.Map.Strict as Map

--- a/src/DearImGui/Raw/DrawList.hs
+++ b/src/DearImGui/Raw/DrawList.hs
@@ -115,7 +115,7 @@ import Foreign hiding (new)
 import Foreign.C
 
 -- dear-imgui
-import DearImGui.Context
+import DearImGui.Raw.Context
   ( imguiContext )
 import DearImGui.Enums
 import DearImGui.Structs

--- a/src/DearImGui/Raw/Font.hs
+++ b/src/DearImGui/Raw/Font.hs
@@ -41,7 +41,7 @@ import Foreign ( Ptr, castPtr )
 import Foreign.C
 
 -- dear-imgui
-import DearImGui.Context
+import DearImGui.Raw.Context
   ( imguiContext )
 import DearImGui.Structs
 import DearImGui.Raw.Font.Config

--- a/src/DearImGui/Raw/Font/Config.hs
+++ b/src/DearImGui/Raw/Font/Config.hs
@@ -46,7 +46,7 @@ import Foreign ( Ptr )
 import Foreign.C
 
 -- dear-imgui
-import DearImGui.Context
+import DearImGui.Raw.Context
   ( imguiContext )
 import DearImGui.Structs
 import DearImGui.Raw.Font.GlyphRanges

--- a/src/DearImGui/Raw/Font/GlyphRanges.hs
+++ b/src/DearImGui/Raw/Font/GlyphRanges.hs
@@ -75,7 +75,7 @@ import Foreign.C
 import System.IO.Unsafe (unsafePerformIO)
 
 -- dear-imgui
-import DearImGui.Context
+import DearImGui.Raw.Context
   ( imguiContext )
 import DearImGui.Structs
 

--- a/src/DearImGui/Raw/IO.hs
+++ b/src/DearImGui/Raw/IO.hs
@@ -39,7 +39,7 @@ import Foreign.C
   )
 
 -- dear-imgui
-import DearImGui.Context
+import DearImGui.Raw.Context
   ( imguiContext )
 -- import DearImGui.Enums
 -- import DearImGui.Structs

--- a/src/DearImGui/Raw/ListClipper.hs
+++ b/src/DearImGui/Raw/ListClipper.hs
@@ -59,7 +59,7 @@ import Foreign.C
 import System.IO.Unsafe (unsafePerformIO)
 
 -- dear-imgui
-import DearImGui.Context
+import DearImGui.Raw.Context
   ( imguiContext )
 import DearImGui.Structs
   ( ImGuiListClipper )


### PR DESCRIPTION
I required this module to implement an extension to dear-imgui (gradient editor based on a c++ gist)
I moved `DearImGui.Context` to `.Raw` and exposed it from the cabal file.

