### PR TITLE
Add getCursorPos

### DIFF
--- a/src/DearImGui.hs
+++ b/src/DearImGui.hs
@@ -110,6 +110,7 @@ module DearImGui
   , Raw.endGroup
 
   , setCursorPos
+  , Raw.getCursorPos
   , Raw.alignTextToFramePadding
 
     -- * ID stack

--- a/src/DearImGui/Raw.hs
+++ b/src/DearImGui/Raw.hs
@@ -90,6 +90,7 @@ module DearImGui.Raw
   , popItemWidth
   , beginGroup
   , endGroup
+  , getCursorPos
   , setCursorPos
   , getCursorScreenPos
   , alignTextToFramePadding
@@ -1670,6 +1671,20 @@ alignTextToFramePadding = liftIO do
 setCursorPos :: (MonadIO m) => Ptr ImVec2 -> m ()
 setCursorPos posPtr = liftIO do
   [C.exp| void { SetCursorPos(*$(ImVec2* posPtr)) } |]
+
+-- | Get cursor position in window-local coordinates.
+--
+-- Useful to overlap draw using 'setCursorPos'.
+--
+-- Wraps @ImGui::SetCursorPos()@
+getCursorPos :: (MonadIO m) => m ImVec2
+getCursorPos = liftIO do
+  C.withPtr_ \ptr ->
+    [C.block|
+      void {
+        *$(ImVec2 * ptr) = GetCursorPos();
+      }
+    |]
 
 -- | Cursor position in absolute coordinates.
 --


### PR DESCRIPTION
Get cursor position in window-local coordinates.
Useful to overlap draw using 'setCursorPos'.