### PR TITLE
Fix vulkan init wrapper

### DIFF
--- a/src/DearImGui/Vulkan.hs
+++ b/src/DearImGui/Vulkan.hs
@@ -134,6 +134,8 @@ vulkanInit ( InitInfo {..} ) renderPass = do
           initInfo.MSAASamples = $(VkSampleCountFlagBits msaaSamples);
           initInfo.Allocator = $(VkAllocationCallbacks* callbacksPtr);
           initInfo.CheckVkResultFn = $( void (*checkResultFunPtr)(VkResult) );
+          initInfo.UseDynamicRendering = false;
+          // TODO: initInfo.ColorAttachmentFormat
           return ImGui_ImplVulkan_Init(&initInfo, $(VkRenderPass renderPass) );
         }|]
     pure ( checkResultFunPtr, initResult /= 0 )


### PR DESCRIPTION
`init_info` got dynamic render flag, which is a breaking change with its default value. Setting it to `false` will fix validation errors coming from misconfiguration.