### PR TITLE
Update README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,29 +31,30 @@ package dear-imgui
 With this done, the following module is the "Hello, World!" of ImGui:
 
 ``` haskell
-{-# language BlockArguments #-}
-{-# language LambdaCase #-}
 {-# language OverloadedStrings #-}
 
 module Main ( main ) where
 
-import Control.Exception
-import Control.Monad.IO.Class
-import Control.Monad.Managed
 import DearImGui
-import DearImGui.OpenGL2
+import DearImGui.OpenGL3
 import DearImGui.SDL
 import DearImGui.SDL.OpenGL
+
 import Graphics.GL
 import SDL
+
+import Control.Monad.Managed
+import Control.Monad.IO.Class ()
+import Control.Monad (when, unless)
+import Control.Exception (bracket, bracket_)
 
 main :: IO ()
 main = do
   -- Initialize SDL
   initializeAll
 
-  runManaged do
-    -- Create a window using SDL. As we're using OpenGL, we need to enable OpenGL too.
+  runManaged $ do
+    -- Create a window using SDL; as we're using OpenGL, we enable OpenGL too
     window <- do
       let title = "Hello, Dear ImGui!"
       let config = defaultWindow { windowGraphicsContext = OpenGLContext defaultOpenGL }
@@ -61,64 +62,59 @@ main = do
 
     -- Create an OpenGL context
     glContext <- managed $ bracket (glCreateContext window) glDeleteContext
-
     -- Create an ImGui context
     _ <- managed $ bracket createContext destroyContext
 
     -- Initialize ImGui's SDL2 backend
-    _ <- managed_ $ bracket_ (sdl2InitForOpenGL window glContext) sdl2Shutdown
-
+    managed_ $ bracket_ (sdl2InitForOpenGL window glContext) sdl2Shutdown
     -- Initialize ImGui's OpenGL backend
-    _ <- managed_ $ bracket_ openGL2Init openGL2Shutdown
+    managed_ $ bracket_ openGL3Init openGL3Shutdown
 
     liftIO $ mainLoop window
 
-
 mainLoop :: Window -> IO ()
-mainLoop window = unlessQuit do
+mainLoop window = unlessQuit $ do
   -- Tell ImGui we're starting a new frame
-  openGL2NewFrame
+  openGL3NewFrame
   sdl2NewFrame
   newFrame
 
   -- Build the GUI
-  withWindowOpen "Hello, ImGui!" do
+  withWindowOpen "Hello, ImGui!" $ do
     -- Add a text widget
     text "Hello, ImGui!"
 
     -- Add a button widget, and call 'putStrLn' when it's clicked
-    button "Clickety Click" >>= \case
-      False -> return ()
-      True  -> putStrLn "Ow!"
+    button "Clickety Click" >>= \clicked ->
+      when clicked $ putStrLn "Ow!"
 
   -- Show the ImGui demo window
   showDemoWindow
 
   -- Render
   glClear GL_COLOR_BUFFER_BIT
-
   render
-  openGL2RenderDrawData =<< getDrawData
+  openGL3RenderDrawData =<< getDrawData
 
   glSwapWindow window
-
   mainLoop window
-
   where
-    -- Process the event loop
-    unlessQuit action = do
-      shouldQuit <- checkEvents
-      if shouldQuit then pure () else action
+  -- Process the event loop
+  unlessQuit action = do
+    shouldQuit <- gotQuitEvent
+    unless shouldQuit action
 
-    checkEvents = do
-      pollEventWithImGui >>= \case
-        Nothing ->
-          return False
-        Just event ->
-          (isQuit event ||) <$> checkEvents
+  gotQuitEvent = do
+    ev <- pollEventWithImGui
 
-    isQuit event =
-      SDL.eventPayload event == SDL.QuitEvent
+    case ev of
+      Nothing ->
+        return False
+      Just event ->
+        (isQuit event ||) <$> gotQuitEvent
+
+  isQuit event =
+    eventPayload event == QuitEvent
 ```
 
 # Hacking


### PR DESCRIPTION
Update the README example to use OpenGL 3 instead of OpenGL 2, following the suggested package flags.

Not only does this modernise the example to use a more recent OpenGL version, it also prevents possible confusion for a beginner where the example doesn't work. This is because the code uses OpenGL 2 whereas the README suggests using the `opengl3` flag (see #95).

Some other minor improvements:

- Remove the use of unnecessary extensions like `BlockArguments` that some people might not be familiar with
- Specify some imports more precisely
- Simplify some control flow