### PR TITLE
Link against system-cxx-std-lib for GHC 9.4+

### DIFF
--- a/dear-imgui.cabal
+++ b/dear-imgui.cabal
@@ -179,8 +179,15 @@ library
     imgui/imgui_draw.cpp
     imgui/imgui_tables.cpp
     imgui/imgui_widgets.cpp
-  extra-libraries:
-    stdc++
+  if impl(ghc >= 9.4)
+    build-depends: system-cxx-std-lib
+  else
+    if os(linux)
+      extra-libraries: stdc++
+    if os(darwin)
+      extra-libraries: stdc++
+    if os(windows)
+      extra-libraries: stdc++
   include-dirs:
     imgui
   build-depends:

--- a/dear-imgui.cabal
+++ b/dear-imgui.cabal
@@ -182,12 +182,7 @@ library
   if impl(ghc >= 9.4)
     build-depends: system-cxx-std-lib
   else
-    if os(linux)
-      extra-libraries: stdc++
-    if os(darwin)
-      extra-libraries: stdc++
-    if os(windows)
-      extra-libraries: stdc++
+    extra-libraries: stdc++
   include-dirs:
     imgui
   build-depends:


### PR DESCRIPTION
When testing a Windows application using `dear-imgui` and `file-embed` with GHC 9.4.8, I bumped into [this build issue](https://gitlab.haskell.org/ghc/ghc/-/issues/22738):

```
<no location info>: error:
    addDLL: stdc++ or dependencies not loaded. (Win32 error 126)
```

The same application worked fine on Mac and I'm not yet familiar enough with Windows development to understand why the Windows side wasn't happy. Regardless, following the recommendation in the linked issue and the GHC 9.4 migration guide to [link against the virtual `system-cxx-std-lib` instead of `stdc++`](https://gitlab.haskell.org/ghc/ghc/-/wikis/migration/9.4#link-against-system-cxx-std-lib-instead-of-stdc) for 9.4+ gets things working on Windows and the Mac build continues to work.

---

Unrelated to this PR's changes, but I also hit the error described in #58 when trying to get the Windows build working. I'm assuming this is a problem with `stack`'s behavior on Windows, where it seemingly does not fetch the `imgui` submodule. `stack` _does_ get the submodule on Mac without issue. I worked around this on Windows for now by depending on a local copy of `dear-imgui` that had the submodule contents manually fetched.

Ideally the issue in `stack` will get resolved and it's something I'd like to look at time-permitting, but as food for thought, I wonder if friction would be reduced in the long run if this repo included a copy of the ImGui source rather than submoduling it in.