### PR TITLE
Adjust vulkan text constraint for ghc-9.8

### DIFF
--- a/dear-imgui.cabal
+++ b/dear-imgui.cabal
@@ -405,7 +405,7 @@ executable vulkan
       , sdl2
           >= 2.5.3.0 && < 2.6
       , text
-          >= 1.2.4 && < 2.1
+          >= 1.2.4 && < 2.2
       , transformers
           >= 0.5.6 && < 0.7
       , unliftio


### PR DESCRIPTION
This change relax the vulkan executable constraint to match the one of the library.