### PR TITLE
Set proper sdl2 min bound

### DIFF
--- a/dear-imgui.cabal
+++ b/dear-imgui.cabal
@@ -252,7 +252,7 @@ library
     exposed-modules:
       DearImGui.SDL
     build-depends:
-      sdl2
+      sdl2 >= 2
     cxx-sources:
       imgui/backends/imgui_impl_sdl2.cpp
 


### PR DESCRIPTION
This change prevents building against sdl2 version 1 which does not have the necessary exposed modules.