### PR TITLE
Expose Vulkan dynamic rendering

### DIFF
--- a/examples/vulkan/Main.hs
+++ b/examples/vulkan/Main.hs
@@ -387,14 +387,16 @@ app = do
       , device
       , queueFamily
       , queue
-      , pipelineCache  = Vulkan.NULL_HANDLE
-      , descriptorPool = imGuiDescriptorPool
-      , subpass        = 0
+      , pipelineCache         = Vulkan.NULL_HANDLE
+      , descriptorPool        = imGuiDescriptorPool
+      , subpass               = 0
       , minImageCount
       , imageCount
-      , msaaSamples    = Vulkan.SAMPLE_COUNT_1_BIT
-      , mbAllocator    = Nothing
-      , checkResult    = \case { Vulkan.SUCCESS -> pure (); e -> throw $ Vulkan.VulkanException e }
+      , msaaSamples           = Vulkan.SAMPLE_COUNT_1_BIT
+      , mbAllocator           = Nothing
+      , useDynamicRendering   = False
+      , colorAttachmentFormat = Nothing
+      , checkResult           = \case { Vulkan.SUCCESS -> pure (); e -> throw $ Vulkan.VulkanException e }
       }
 
   logDebug "Initialising ImGui SDL2 for Vulkan"

--- a/src/DearImGui/Vulkan.hs
+++ b/src/DearImGui/Vulkan.hs
@@ -72,20 +72,21 @@ Cpp.using "namespace ImGui"
 
 data InitInfo =
   InitInfo
-  { instance'           :: !Vulkan.Instance
-  , physicalDevice      :: !Vulkan.PhysicalDevice
-  , device              :: !Vulkan.Device
-  , queueFamily         :: !Word32
-  , queue               :: !Vulkan.Queue
-  , pipelineCache       :: !Vulkan.PipelineCache
-  , descriptorPool      :: !Vulkan.DescriptorPool
-  , subpass             :: !Word32
-  , minImageCount       :: !Word32
-  , imageCount          :: !Word32
-  , msaaSamples         :: !Vulkan.SampleCountFlagBits
-  , useDynamicRendering :: !Bool
-  , mbAllocator         :: Maybe Vulkan.AllocationCallbacks
-  , checkResult         :: Vulkan.Result -> IO ()
+  { instance'             :: !Vulkan.Instance
+  , physicalDevice        :: !Vulkan.PhysicalDevice
+  , device                :: !Vulkan.Device
+  , queueFamily           :: !Word32
+  , queue                 :: !Vulkan.Queue
+  , pipelineCache         :: !Vulkan.PipelineCache
+  , descriptorPool        :: !Vulkan.DescriptorPool
+  , subpass               :: !Word32
+  , minImageCount         :: !Word32
+  , imageCount            :: !Word32
+  , msaaSamples           :: !Vulkan.SampleCountFlagBits
+  , colorAttachmentFormat :: !(Maybe Vulkan.Format)
+  , useDynamicRendering   :: !Bool
+  , mbAllocator           :: Maybe Vulkan.AllocationCallbacks
+  , checkResult           :: Vulkan.Result -> IO ()
   }
 
 -- | Wraps @ImGui_ImplVulkan_Init@ and @ImGui_ImplVulkan_Shutdown@.
@@ -115,8 +116,10 @@ vulkanInit ( InitInfo {..} ) renderPass = do
     withCallbacks f = case mbAllocator of
       Nothing        -> f nullPtr
       Just callbacks -> alloca ( \ ptr -> poke ptr callbacks *> f ptr )
-    useDynamicRenderingCBool :: Cpp.CBool
-    useDynamicRenderingCBool = fromBool useDynamicRendering
+    useDynamicRendering' :: Cpp.CBool
+    useDynamicRendering' = fromBool useDynamicRendering
+    colorAttachmentFormat' :: Vulkan.Format
+    colorAttachmentFormat' = fromMaybe Vulkan.FORMAT_UNDEFINED colorAttachmentFormat
   liftIO do
     checkResultFunPtr <- $( C.mkFunPtr [t| Vulkan.Result -> IO () |] ) checkResult
     initResult <- withCallbacks \ callbacksPtr ->
@@ -139,8 +142,8 @@ vulkanInit ( InitInfo {..} ) renderPass = do
           initInfo.MSAASamples = $(VkSampleCountFlagBits msaaSamples);
           initInfo.Allocator = $(VkAllocationCallbacks* callbacksPtr);
           initInfo.CheckVkResultFn = $( void (*checkResultFunPtr)(VkResult) );
-          initInfo.UseDynamicRendering = $(bool useDynamicRenderingCBool);
-          // TODO: initInfo.ColorAttachmentFormat
+          initInfo.UseDynamicRendering = $(bool useDynamicRendering');
+          initInfo.ColorAttachmentFormat = $(VkFormat colorAttachmentFormat');
           return ImGui_ImplVulkan_Init(&initInfo, $(VkRenderPass renderPass) );
         }|]
     pure ( checkResultFunPtr, initResult /= 0 )

--- a/src/DearImGui/Vulkan/Types.hs
+++ b/src/DearImGui/Vulkan/Types.hs
@@ -35,6 +35,7 @@ vulkanTypesTable = Map.fromList
   , ( C.TypeName "VkImageView"          , [t| Vulkan.ImageView           |] )
   , ( C.TypeName "VkImageLayout"        , [t| Vulkan.ImageLayout         |] )
   , ( C.TypeName "VkDescriptorSet"      , [t| Vulkan.DescriptorSet       |] )
+  , ( C.TypeName "VkFormat"             , [t| Vulkan.Format              |])
   ]
 
 vulkanCtx :: C.Context


### PR DESCRIPTION
Exposes two new properties for the Vulkan implementation:

- `useDynamicRendering` - for use in more modern dynamic rendering pipelines
- `colorAttachmentFormat` - [required to enable dynamic rendering
](https://github.com/ocornut/imgui/blob/6f7b5d0ee2fe9948ab871a530888a6dc5c960700/backends/imgui_impl_vulkan.cpp#L49)

Relevant Vulkan docs:

- https://github.com/KhronosGroup/Vulkan-Docs/blob/main/proposals/VK_KHR_dynamic_rendering.adoc

There may be more considerations here, but this seems to work as-is so far as I can tell.