### PR TITLE
Add Tree Node function that accepts flags

### DIFF
--- a/src/DearImGui.hs
+++ b/src/DearImGui.hs
@@ -283,6 +283,7 @@ module DearImGui
 
     -- ** Trees
   , treeNode
+  , treeNodeWith
   , treePush
   , Raw.treePop
   , setNextItemOpen
@@ -1958,6 +1959,10 @@ treeNode :: MonadIO m => Text -> m Bool
 treeNode label = liftIO do
   Text.withCString label Raw.treeNode
 
+-- | Wraps @ImGui::TreeNodeEx()@.
+treeNodeWith :: MonadIO m => Text -> ImGuiTreeNodeFlags -> m Bool
+treeNodeWith label flags = liftIO do
+  Text.withCString label (flip Raw.treeNodeEx flags)
 
 -- | Wraps @ImGui::TreePush()@.
 treePush :: MonadIO m => Text -> m ()

--- a/src/DearImGui/Raw.hs
+++ b/src/DearImGui/Raw.hs
@@ -245,6 +245,7 @@ module DearImGui.Raw
 
     -- * Trees
   , treeNode
+  , treeNodeEx
   , treePush
   , treePop
   , getTreeNodeToLabelSpacing
@@ -1520,6 +1521,10 @@ treeNode :: (MonadIO m) => CString -> m Bool
 treeNode labelPtr = liftIO do
   (0 /=) <$> [C.exp| bool { TreeNode($(char* labelPtr)) } |]
 
+-- | Wraps @ImGui::TreeNodeEx()@.
+treeNodeEx :: (MonadIO m) => CString -> ImGuiTreeNodeFlags -> m Bool
+treeNodeEx labelPtr flags = liftIO do
+  (0 /=) <$> [C.exp| bool { TreeNodeEx($(char* labelPtr), $(ImGuiTreeNodeFlags flags)) } |]
 
 -- | Wraps @ImGui::TreePush()@.
 treePush :: (MonadIO m) => CString -> m ()


### PR DESCRIPTION
If, for example, you want to 'select' a tree node, you would need to pass in the ImGuiTreeNodeFlags_Selected flag. This function allows rendering tree nodes with flags.