### PR TITLE
Update imgui dependency to 1.91.3 (Released 2024-10-04)

### DIFF
--- a/examples/sdl/Image.hs
+++ b/examples/sdl/Image.hs
@@ -23,6 +23,7 @@ import qualified SDL as SDL
 
 --  For the texture creation
 import Foreign
+import Foreign.C.String
 import qualified Data.Vector.Storable as VS
 
 data Texture = Texture
@@ -152,7 +153,8 @@ mainLoop window textures flag = unlessQuit do
           Foreign.with (ImVec2 1 1) \uv1Ptr ->
             Foreign.with (ImVec4 1 1 1 1) \tintColPtr ->
               Foreign.with (ImVec4 1 1 1 1) \bgColPtr ->
-                Raw.imageButton nullPtr openGLtextureID sizePtr uv0Ptr uv1Ptr bgColPtr tintColPtr
+                withCString "##btn" \idPtr ->
+                  Raw.imageButton idPtr openGLtextureID sizePtr uv0Ptr uv1Ptr bgColPtr tintColPtr
     else
       pure False
 

--- a/examples/sdl/Image.hs
+++ b/examples/sdl/Image.hs
@@ -152,7 +152,7 @@ mainLoop window textures flag = unlessQuit do
           Foreign.with (ImVec2 1 1) \uv1Ptr ->
             Foreign.with (ImVec4 1 1 1 1) \tintColPtr ->
               Foreign.with (ImVec4 1 1 1 1) \bgColPtr ->
-                Raw.imageButton openGLtextureID sizePtr uv0Ptr uv1Ptr (-1) bgColPtr tintColPtr
+                Raw.imageButton nullPtr openGLtextureID sizePtr uv0Ptr uv1Ptr bgColPtr tintColPtr
     else
       pure False
 

--- a/examples/vulkan/Main.hs
+++ b/examples/vulkan/Main.hs
@@ -81,7 +81,7 @@ import qualified DearImGui.Vulkan     as ImGui.Vulkan
 import qualified DearImGui.SDL        as ImGui.SDL
 import qualified DearImGui.SDL.Vulkan as ImGui.SDL.Vulkan
 import Util (vmaVulkanFunctions)
-import Foreign (Ptr, castPtr, copyBytes, with, withForeignPtr, wordPtrToPtr)
+import Foreign (Ptr, castPtr, copyBytes, with, withForeignPtr, wordPtrToPtr, nullPtr)
 import qualified DearImGui.Raw as ImGui.Raw
 import UnliftIO (MonadUnliftIO)
 import qualified Vulkan.CStruct.Extends as Vulkan
@@ -111,11 +111,11 @@ gui texture = do
             with (ImGui.Raw.ImVec4 1 1 1 1) \tintColPtr ->
               with (ImGui.Raw.ImVec4 1 1 1 1) \bgColPtr ->
                 ImGui.Raw.imageButton
+                  nullPtr
                   (snd texture)
                   sizePtr
                   uv0Ptr
                   uv1Ptr
-                  (-1)
                   bgColPtr
                   tintColPtr
 

--- a/generator/DearImGui/Generator/Parser.hs
+++ b/generator/DearImGui/Generator/Parser.hs
@@ -143,7 +143,7 @@ headers = do
       )
       ( try $ many comment >> keyword "struct" >> identifier)
 
-  _ <- skipManyTill anySingle ( namedSection "Helpers: Memory allocations macros, ImVector<>" )
+  _ <- skipManyTill anySingle ( namedSection "Helpers: Debug log, memory allocations macros, ImVector<>" )
 
   _ <- skipManyTill anySingle ( namedSection "ImGuiStyle" )
 
@@ -152,6 +152,8 @@ headers = do
   _ <- skipManyTill anySingle ( namedSection "Misc data structures" )
 
   _ <- skipManyTill anySingle ( namedSection "Helpers (ImGuiOnceUponAFrame, ImGuiTextFilter, ImGuiTextBuffer, ImGuiStorage, ImGuiListClipper, Math Operators, ImColor)" )
+
+  _ <- skipManyTill anySingle ( namedSection "Multi-Select API flags and structures (ImGuiMultiSelectFlags, ImGuiSelectionRequestType, ImGuiSelectionRequest, ImGuiMultiSelectIO, ImGuiSelectionBasicStorage)" )
 
   _ <- skipManyTill anySingle ( namedSection "Drawing API (ImDrawCmd, ImDrawIdx, ImDrawVert, ImDrawChannel, ImDrawListSplitter, ImDrawListFlags, ImDrawList, ImDrawData)" )
   skipManyTill anySingle ( try . lookAhead $ many comment *> keyword "enum" )

--- a/src/DearImGui/Raw.hs
+++ b/src/DearImGui/Raw.hs
@@ -823,22 +823,21 @@ image userTextureIDPtr sizePtr uv0Ptr uv1Ptr tintColPtr borderColPtr = liftIO do
 -- Negative @frame_padding@ uses default frame padding settings. Set to 0 for no padding.
 --
 -- Wraps @ImGui::ImageButton()@.
-imageButton :: (MonadIO m) => Ptr () -> Ptr ImVec2 -> Ptr ImVec2 -> Ptr ImVec2 -> CInt -> Ptr ImVec4 -> Ptr ImVec4 -> m Bool
-imageButton userTextureIDPtr sizePtr uv0Ptr uv1Ptr framePadding bgColPtr tintColPtr = liftIO do
+imageButton :: (MonadIO m) => CString -> Ptr () -> Ptr ImVec2 -> Ptr ImVec2 -> Ptr ImVec2 -> Ptr ImVec4 -> Ptr ImVec4 -> m Bool
+imageButton labelPtr userTextureIDPtr sizePtr uv0Ptr uv1Ptr bgColPtr tintColPtr = liftIO do
   (0 /=) <$> [C.exp|
     bool {
       ImageButton(
+        $(char* labelPtr),
         $(void* userTextureIDPtr),
         *$(ImVec2* sizePtr),
         *$(ImVec2* uv0Ptr),
         *$(ImVec2* uv1Ptr),
-        $(int framePadding),
         *$(ImVec4* bgColPtr),
         *$(ImVec4* tintColPtr)
       )
     }
   |]
-
 
 -- | Wraps @ImGui::Checkbox()@.
 checkbox :: (MonadIO m) => CString -> Ptr CBool -> m Bool


### PR DESCRIPTION
This is a small PR which does the minimum work required to update imgui to 1.91.3. No new features are supported. The one breaking change is that it changes the signature of `imageButton`.

This is needed for SDL3 support, which will come in a separate PR (and depends on the yet unreleased sdl3-hs package). 1.91.3 is the first version that comes close enough to the current version of SDL3 to support it.

I believe this closes #214 