### PR TITLE
SDL3 Renderer support

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,4 +1,10 @@
 packages: *.cabal
 package dear-imgui
-  flags: +sdl +sdl-renderer +glfw +opengl2 +opengl3 +vulkan +examples
+  flags: -sdl +sdl3 +sdl-renderer +glfw +opengl2 +opengl3 +vulkan +examples
   ghc-options: -Wall -Wcompat -fno-warn-unused-do-bind
+
+
+source-repository-package
+    type: git
+    location: https://github.com/klukaszek/sdl3-hs.git
+    tag: 932406e5476feffbaa4394c1f642cb6d0b5cc9f0

--- a/cabal.project
+++ b/cabal.project
@@ -1,6 +1,6 @@
 packages: *.cabal
 package dear-imgui
-  flags: +sdl +sdl3 +sdl-renderer +glfw +opengl2 +opengl3 +vulkan +examples
+  flags: +sdl -sdl3 +sdl-renderer +glfw +opengl2 +opengl3 +vulkan +examples
   ghc-options: -Wall -Wcompat -fno-warn-unused-do-bind
 
 

--- a/cabal.project
+++ b/cabal.project
@@ -1,10 +1,10 @@
 packages: *.cabal
 package dear-imgui
-  flags: -sdl +sdl3 +sdl-renderer +glfw +opengl2 +opengl3 +vulkan +examples
+  flags: +sdl +sdl3 +sdl-renderer +glfw +opengl2 +opengl3 +vulkan +examples
   ghc-options: -Wall -Wcompat -fno-warn-unused-do-bind
 
 
 source-repository-package
     type: git
     location: https://github.com/klukaszek/sdl3-hs.git
-    tag: 932406e5476feffbaa4394c1f642cb6d0b5cc9f0
+    tag: aa9777f4d5bce4121e65d88b8f35a3fd874c817a

--- a/dear-imgui.cabal
+++ b/dear-imgui.cabal
@@ -94,6 +94,14 @@ flag sdl
   manual:
     True
 
+flag sdl3
+  description:
+    Enable SDL3 backend.
+  default:
+    True
+  manual:
+    True
+
 flag sdl-renderer
   description:
     Enable SDL Renderer backend (requires the SDL_RenderGeometry function available in SDL 2.0.18+).
@@ -283,6 +291,27 @@ library
       cxx-sources:
         imgui/backends/imgui_impl_sdlrenderer2.cpp
 
+  if flag(sdl3)
+    exposed-modules:
+      DearImGui.SDL3
+    build-depends:
+      sdl3
+    cxx-sources:
+      imgui/backends/imgui_impl_sdl3.cpp
+
+    if os(windows) || os(darwin)
+      extra-libraries:
+        SDL3
+    else
+      pkgconfig-depends:
+        sdl3
+
+    if flag(sdl-renderer)
+      exposed-modules:
+        DearImGui.SDL3.Renderer
+      cxx-sources:
+        imgui/backends/imgui_impl_sdlrenderer3.cpp
+
   if flag(glfw)
     exposed-modules:
       DearImGui.GLFW
@@ -324,7 +353,7 @@ library dear-imgui-generator
     , inline-c
         >= 0.9.0.0 && < 0.10
     , megaparsec
-        >= 9.0 && < 9.7
+        >= 9.0 && < 9.8
     , parser-combinators
         >= 1.2.0 && < 1.4
     , scientific
@@ -387,6 +416,14 @@ executable sdlrenderer
   hs-source-dirs: examples/sdl
   build-depends: sdl2, dear-imgui, managed, text
   if (!flag(examples) || !flag(sdl) || !flag(sdl-renderer))
+    buildable: False
+
+executable sdl3renderer
+  import: common, exe-flags
+  main-is: Renderer.hs
+  hs-source-dirs: examples/sdl3
+  build-depends: sdl3, dear-imgui, managed, text
+  if (!flag(examples) || !flag(sdl3) || !flag(sdl-renderer))
     buildable: False
 
 executable vulkan

--- a/dear-imgui.cabal
+++ b/dear-imgui.cabal
@@ -98,7 +98,7 @@ flag sdl3
   description:
     Enable SDL3 backend.
   default:
-    True
+    False
   manual:
     True
 

--- a/examples/sdl3/Renderer.hs
+++ b/examples/sdl3/Renderer.hs
@@ -81,33 +81,6 @@ main = do
                             sdlLog "Renderer destroyed."
         pure ()
 
--- case window of
---     Nothing -> do
---         sdlLog "Failed to create window!"
---         sdlQuit
---         exitFailure
---     Just win -> do
---         sdlLog "Window created successfully!"
-
---         -- Create a Renderer
---         renderer <- sdlCreateRenderer win Nothing -- Let SDL choose
---         case renderer of
---             Nothing -> do
---                 sdlLog "Failed to create default renderer!"
---                 err <- sdlGetError
---                 sdlLog $ "SDL Error: " ++ err
---                 sdlDestroyWindow win
---                 sdlQuit
---                 exitFailure
---             Just ren -> do
---                 mRendererName <- sdlGetRendererName ren
---                 sdlLog $ "Created renderer: " ++ fromMaybe "Unknown" mRendererName
---                 runApp win ren -- Pass window and renderer to runApp
--- sdlLog "Shutting down SDL..."
--- sdlQuit
--- sdlLog "Application terminated successfully"
--- exitSuccess
-
 -- | Encapsulate the application logic with window and renderer
 runApp :: SDLWindow -> SDLRenderer -> IO ()
 runApp win renderer = do

--- a/examples/sdl3/Renderer.hs
+++ b/examples/sdl3/Renderer.hs
@@ -1,0 +1,299 @@
+module Main where
+
+-- Used for rendererName
+
+import Control.Exception (bracket)
+import Control.Exception.Base (bracket_)
+import Control.Monad (unless, when)
+import Control.Monad.Managed
+import Data.IORef
+import Data.Maybe (fromMaybe)
+import Data.Word (Word64)
+import DearImGui
+import DearImGui.SDL3
+import DearImGui.SDL3.Renderer
+import SDL
+import System.Exit (exitFailure, exitSuccess)
+import Text.Printf (printf)
+
+-- Key state IORefs type alias for clarity
+type KeyStates = (IORef Bool, IORef Bool, IORef Bool, IORef Bool) -- Up, Down, Left, Right
+
+main :: IO ()
+main = do
+    -- Check compiled version
+    sdlLog $ "Compiled SDL Version: " ++ show sdlVersion
+    when (sdlVersionAtLeast 3 3 0) $ sdlLog "Compiled with at least SDL 3.3.0"
+
+    -- Get linked version
+    linkedVersion <- sdlGetVersion
+    sdlLog $ "Linked SDL Version: " ++ show linkedVersion
+
+    -- Initialize SDL (Events are implicitly initialized by Video, but explicit is fine)
+    initSuccess <- sdlInit [SDL_INIT_VIDEO, SDL_INIT_EVENTS]
+    unless initSuccess $ do
+        sdlLog "Failed to initialize SDL!"
+        exitFailure
+
+    -- Check initialized subsystems
+    initializedSystems <- sdlWasInit []
+    sdlLog "Initialized subsystems:"
+    mapM_ printSubsystem initializedSystems
+
+    -- Create a window
+    runManaged $ do
+        window <- do
+            let createAction = sdlCreateWindow "SDL3 Haskell Render Example" 800 600 [SDL_WINDOW_RESIZABLE]
+            managed $ bracket createAction (maybe (error "Bad window") sdlDestroyWindow)
+        case window of
+            Nothing -> liftIO $ do
+                sdlLog "Failed to create window!"
+                sdlQuit
+                exitFailure
+            Just win -> do
+                liftIO $ sdlLog "Window created successfully!"
+
+                -- Create a Renderer
+                renderer <- managed $ bracket (sdlCreateRenderer win Nothing) (error "no renderer" sdlDestroyRenderer) -- Let SDL choose
+                case renderer of
+                    Nothing -> liftIO $ do
+                        sdlLog "Failed to create default renderer!"
+                        err <- sdlGetError
+                        sdlLog $ "SDL Error: " ++ err
+                        sdlDestroyWindow win
+                        sdlQuit
+                        exitFailure
+                    Just ren -> do
+                        _ <- managed $ bracket createContext destroyContext
+                        _ <- managed_ $ do
+                            bracket_ (sdl3InitForSDLRenderer win ren) sdl3Shutdown
+                        _ <- managed_ $ bracket_ (sdl3RendererInit ren) sdl3RendererShutdown
+                        liftIO $ do
+                            mRendererName <- sdlGetRendererName ren
+                            sdlLog $ "Created renderer: " ++ fromMaybe "Unknown" mRendererName
+
+                            -- Run the application logic
+                            runApp win ren
+
+                            -- Cleanup
+                            sdlLog "Destroying renderer..."
+                            sdlDestroyRenderer ren
+                            sdlLog "Renderer destroyed."
+        pure ()
+
+-- case window of
+--     Nothing -> do
+--         sdlLog "Failed to create window!"
+--         sdlQuit
+--         exitFailure
+--     Just win -> do
+--         sdlLog "Window created successfully!"
+
+--         -- Create a Renderer
+--         renderer <- sdlCreateRenderer win Nothing -- Let SDL choose
+--         case renderer of
+--             Nothing -> do
+--                 sdlLog "Failed to create default renderer!"
+--                 err <- sdlGetError
+--                 sdlLog $ "SDL Error: " ++ err
+--                 sdlDestroyWindow win
+--                 sdlQuit
+--                 exitFailure
+--             Just ren -> do
+--                 mRendererName <- sdlGetRendererName ren
+--                 sdlLog $ "Created renderer: " ++ fromMaybe "Unknown" mRendererName
+--                 runApp win ren -- Pass window and renderer to runApp
+-- sdlLog "Shutting down SDL..."
+-- sdlQuit
+-- sdlLog "Application terminated successfully"
+-- exitSuccess
+
+-- | Encapsulate the application logic with window and renderer
+runApp :: SDLWindow -> SDLRenderer -> IO ()
+runApp win renderer = do
+    startTime <- sdlGetPerformanceCounter
+    freq <- sdlGetPerformanceFrequency
+    deltaTimeRef <- newIORef 0.0 -- Will store delta time in seconds
+    rectPosRef <- newIORef (SDLFPoint 100 100)
+    shouldQuitRef <- newIORef False
+
+    -- Create IORefs for key states
+    upPressedRef <- newIORef False
+    downPressedRef <- newIORef False
+    leftPressedRef <- newIORef False
+    rightPressedRef <- newIORef False
+    let keyStates = (upPressedRef, downPressedRef, leftPressedRef, rightPressedRef)
+
+    eventLoop win renderer startTime freq deltaTimeRef rectPosRef shouldQuitRef keyStates
+
+    -- Cleanup (happens after eventLoop finishes)
+    sdlLog "Destroying renderer..."
+    sdlDestroyRenderer renderer
+    sdlLog "Renderer destroyed."
+    sdlLog "Destroying window..."
+    sdlDestroyWindow win
+    sdlLog "Window destroyed."
+
+-- | Main event loop
+eventLoop :: SDLWindow -> SDLRenderer -> Word64 -> Word64 -> IORef Double -> IORef SDLFPoint -> IORef Bool -> KeyStates -> IO ()
+eventLoop window renderer lastTime freq deltaTimeRef rectPosRef shouldQuitRef keyStates = do
+    currentTime <- sdlGetPerformanceCounter
+    let deltaTimeInSeconds = fromIntegral (currentTime - lastTime) / fromIntegral freq
+    writeIORef deltaTimeRef deltaTimeInSeconds -- Store delta time in seconds
+
+    -- Event handling: Process all pending events for this frame
+    sdlPumpEvents
+    processEvents shouldQuitRef keyStates -- This will handle multiple events
+    shouldQuit <- readIORef shouldQuitRef
+    unless shouldQuit $ do
+        -- Update game logic based on current key states and delta time
+        updateGameLogic rectPosRef deltaTimeRef keyStates
+
+        -- Render the scene
+        renderFrame renderer rectPosRef
+
+        -- Continue loop
+        eventLoop window renderer currentTime freq deltaTimeRef rectPosRef shouldQuitRef keyStates
+
+-- | Process all pending events from the queue for the current frame
+processEvents :: IORef Bool -> KeyStates -> IO ()
+processEvents shouldQuitRef keyStates = do
+    maybeEvent <- pollEventWithImGui
+    case maybeEvent of
+        Nothing -> return () -- No more events in queue for this frame
+        Just event -> do
+            -- Handle the current event
+            quitSignalFromEvent <- handleSingleEvent event keyStates -- Renamed from handleEvent to avoid clash
+            when quitSignalFromEvent $ writeIORef shouldQuitRef True
+
+            -- Check if we should continue processing events (e.g., if quit wasn't signaled)
+            currentQuitState <- readIORef shouldQuitRef
+            unless currentQuitState $
+                processEvents shouldQuitRef keyStates -- Recursively process next event
+
+-- | Handle a single SDL event, updating key states. Returns True if this event signals a quit.
+handleSingleEvent :: SDLEvent -> KeyStates -> IO Bool
+handleSingleEvent event (upRef, downRef, leftRef, rightRef) = case event of
+    SDLEventQuit _ -> do
+        sdlLog "Quit event received."
+        return True
+    SDLEventKeyboard ke -> do
+        let scancode = sdlKeyboardScancode ke
+        let isKeyDown = sdlKeyboardDown ke
+        let eventType = sdlKeyboardType ke
+        let isRepeat = sdlKeyboardRepeat ke
+
+        sdlLog $
+            printf
+                "Keyboard Event: Type: %s, Scancode: %s, isKeyDown: %s, Repeat: %s"
+                (show eventType)
+                (show scancode)
+                (show isKeyDown)
+                (show isRepeat)
+
+        -- Update IORefs based on key state
+        case scancode of
+            SDL_SCANCODE_Q ->
+                if isKeyDown
+                    then do
+                        -- Quit only on Q press
+                        sdlLog "Q pressed, signaling quit."
+                        return True
+                    else
+                        return False
+            SDL_SCANCODE_UP -> writeIORef upRef isKeyDown >> return False
+            SDL_SCANCODE_DOWN -> writeIORef downRef isKeyDown >> return False
+            SDL_SCANCODE_LEFT -> writeIORef leftRef isKeyDown >> return False
+            SDL_SCANCODE_RIGHT -> writeIORef rightRef isKeyDown >> return False
+            _ -> return False -- Other scancodes don't signal quit by default
+    _ -> return False -- Other event types don't signal quit by default
+
+-- | Update game state (like rectangle position) based on current input states and delta time
+updateGameLogic :: IORef SDLFPoint -> IORef Double -> KeyStates -> IO ()
+updateGameLogic rectPosRef deltaTimeRef (upRef, downRef, leftRef, rightRef) = do
+    dtSec <- readIORef deltaTimeRef -- Delta time of the frame in seconds
+    let moveSpeed = 200.0 -- Pixels per second
+    let moveAmount = realToFrac (moveSpeed * dtSec)
+
+    -- Read current key states
+    up <- readIORef upRef
+    down <- readIORef downRef
+    left <- readIORef leftRef
+    right <- readIORef rightRef
+
+    -- Optional: Log states if debugging movement
+    -- sdlLog $ printf "updateGameLogic: up:%s, down:%s, left:%s, right:%s, dt:%.4fs, move:%.3f"
+    --                 (show up) (show down) (show left) (show right) dtSec moveAmount
+
+    SDLFPoint currentX currentY <- readIORef rectPosRef
+    let newX | left = currentX - moveAmount | right = currentX + moveAmount | otherwise = currentX
+    let newY | up = currentY - moveAmount | down = currentY + moveAmount | otherwise = currentY
+
+    when (newX /= currentX || newY /= currentY) $
+        writeIORef rectPosRef (SDLFPoint newX newY)
+
+-- | Render a single frame
+renderFrame :: SDLRenderer -> IORef SDLFPoint -> IO ()
+renderFrame renderer rectPosRef = do
+    sdl3RendererNewFrame
+    sdl3NewFrame
+    newFrame
+
+    showDemoWindow
+
+    -- 1. Set draw color to clear color (e.g., dark blue) and clear
+    _ <- sdlSetRenderDrawColor renderer 32 32 64 255
+    clearSuccess <- sdlRenderClear renderer
+    unless clearSuccess $ sdlLog "Warning: Failed to clear renderer"
+
+    -- 2. Set draw color for rectangle (e.g., yellow)
+    _ <- sdlSetRenderDrawColor renderer 255 255 0 255
+
+    -- 3. Get current rectangle position
+    (SDLFPoint x y) <- readIORef rectPosRef
+
+    -- 4. Define rectangle geometry
+    let rect = SDLFRect x y 50 50 -- x, y, width, height
+
+    -- 5. Draw the filled rectangle
+    fillRectSuccess <- sdlRenderFillRect renderer (Just rect)
+    unless fillRectSuccess $ sdlLog "Warning: Failed to draw filled rect"
+
+    render
+    sdl3RendererRenderDrawData renderer =<< getDrawData
+
+    -- 6. Present the rendered frame
+    presentSuccess <- sdlRenderPresent renderer
+    unless presentSuccess $ do
+        err <- sdlGetError
+        sdlLog $ "Warning: Failed to present renderer: " ++ err
+
+-- Helper function to print subsystem names
+printSubsystem :: SDLInitFlags -> IO ()
+printSubsystem flag =
+    sdlLog $
+        "  - " ++ case flag of
+            SDL_INIT_AUDIO -> "Audio"
+            SDL_INIT_VIDEO -> "Video"
+            SDL_INIT_JOYSTICK -> "Joystick"
+            SDL_INIT_HAPTIC -> "Haptic"
+            SDL_INIT_GAMEPAD -> "Gamepad"
+            SDL_INIT_EVENTS -> "Events"
+            SDL_INIT_SENSOR -> "Sensor"
+            SDL_INIT_CAMERA -> "Camera"
+            _ -> "Unknown subsystem"
+
+data Refs = Refs
+    { refsShowDemoWindow :: IORef Bool
+    , refsShowAnotherWindow :: IORef Bool
+    , refsFloat :: IORef Float
+    , refsCounter :: IORef Int
+    }
+
+newRefs :: IO Refs
+newRefs =
+    Refs
+        <$> newIORef True
+        <*> newIORef False
+        <*> newIORef 0
+        <*> newIORef 0

--- a/examples/sdl3/Renderer.hs
+++ b/examples/sdl3/Renderer.hs
@@ -12,7 +12,7 @@ import Data.Word (Word64)
 import DearImGui
 import DearImGui.SDL3
 import DearImGui.SDL3.Renderer
-import SDL
+import SDL3
 import System.Exit (exitFailure, exitSuccess)
 import Text.Printf (printf)
 

--- a/src/DearImGui/SDL3.hs
+++ b/src/DearImGui/SDL3.hs
@@ -1,0 +1,110 @@
+{-# LANGUAGE BlockArguments #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE TemplateHaskell #-}
+
+{- |
+Module: DearImGui.SDL
+
+SDL3 specific functions backend for Dear ImGui.
+
+Modules for initialising a backend with SDL3 can be found under the corresponding backend,
+e.g. "DearImGui.SDL.OpenGL".
+-}
+module DearImGui.SDL3 (
+  sdl3NewFrame,
+  sdl3Shutdown,
+  pollEventWithImGui,
+  pollEventsWithImGui,
+)
+where
+
+-- , dispatchRawEvent
+
+-- base
+import Control.Monad (
+  void,
+  when,
+ )
+import Foreign.Marshal.Alloc (
+  alloca,
+ )
+import Foreign.Ptr (
+  Ptr,
+  castPtr,
+ )
+
+-- inline-c
+import qualified Language.C.Inline as C
+
+-- inline-c-cpp
+import qualified Language.C.Inline.Cpp as Cpp
+
+-- sdl3
+
+-- transformers
+import Control.Monad.IO.Class (
+  MonadIO,
+  liftIO,
+ )
+import SDL.Events
+
+C.context (Cpp.cppCtx <> C.bsCtx)
+C.include "imgui.h"
+C.include "backends/imgui_impl_sdl3.h"
+C.include "SDL3/SDL.h"
+Cpp.using "namespace ImGui"
+
+-- | Wraps @ImGui_ImplSDL3_NewFrame@.
+sdl3NewFrame :: (MonadIO m) => m ()
+sdl3NewFrame = liftIO do
+  [C.exp| void { ImGui_ImplSDL3_NewFrame(); } |]
+
+-- | Wraps @ImGui_ImplSDL3_Shutdown@.
+sdl3Shutdown :: (MonadIO m) => m ()
+sdl3Shutdown = liftIO do
+  [C.exp| void { ImGui_ImplSDL3_Shutdown(); } |]
+
+{- | Call the SDL3 'pollEvent' function, while also dispatching the event to
+Dear ImGui. You should use this in your application instead of 'pollEvent'.
+-}
+pollEventWithImGui :: (MonadIO m) => m (Maybe SDLEvent)
+pollEventWithImGui = liftIO do
+  alloca \evPtr -> do
+    sdlPumpEvents
+
+    -- We use NULL first to check if there's an event.
+    nEvents <- sdlPeepEventsRaw evPtr 1 SDL_PEEKEVENT SDL_EVENT_FIRST SDL_EVENT_LAST
+
+    when (nEvents > 0) do
+      void $ dispatchRawEvent evPtr
+
+    sdlPollEvent
+
+{- | Dispatch a raw 'Raw.Event' value to Dear ImGui.
+
+You may want this function instead of 'pollEventWithImGui' if you do not use
+@sdl3@'s higher-level 'Event' type (e.g. your application has its own polling
+mechanism).
+
+__It is your application's responsibility to both manage the input__
+__pointer's memory and to fill the memory location with a raw 'Raw.Event'__
+__value.__
+-}
+dispatchRawEvent :: (MonadIO m) => Ptr SDLEvent -> m Bool
+dispatchRawEvent evPtr = liftIO do
+  let evPtr' = castPtr evPtr :: Ptr ()
+  (0 /=) <$> [C.exp| bool { ImGui_ImplSDL3_ProcessEvent((const SDL_Event*) $(void* evPtr')) } |]
+
+{- | Like the SDL3 'pollEvents' function, while also dispatching the events to
+Dear ImGui. See 'pollEventWithImGui'.
+-}
+pollEventsWithImGui :: (MonadIO m) => m [SDLEvent]
+pollEventsWithImGui = do
+  e <- pollEventWithImGui
+  case e of
+    Nothing -> pure []
+    Just e' -> (e' :) <$> pollEventsWithImGui

--- a/src/DearImGui/SDL3.hs
+++ b/src/DearImGui/SDL3.hs
@@ -50,7 +50,7 @@ import Control.Monad.IO.Class (
   MonadIO,
   liftIO,
  )
-import SDL.Events
+import SDL3.Events
 
 C.context (Cpp.cppCtx <> C.bsCtx)
 C.include "imgui.h"

--- a/src/DearImGui/SDL3/Renderer.hs
+++ b/src/DearImGui/SDL3/Renderer.hs
@@ -1,0 +1,82 @@
+{-# LANGUAGE BlockArguments #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE TemplateHaskell #-}
+
+{- |
+Module: DearImGUI.SDL.Renderer
+
+Initialising the SDL2 renderer backend for Dear ImGui.
+-}
+module DearImGui.SDL3.Renderer (
+    sdl3InitForSDLRenderer,
+    sdl3RendererInit,
+    sdl3RendererShutdown,
+    sdl3RendererNewFrame,
+    sdl3RendererRenderDrawData,
+)
+where
+
+-- inline-c
+import qualified Language.C.Inline as C
+
+-- inline-c-cpp
+import qualified Language.C.Inline.Cpp as Cpp
+
+-- sdl2
+-- import SDL.Internal.Types (
+--     Renderer (..),
+--     Window (..),
+--  )
+
+-- transformers
+import Control.Monad.IO.Class (
+    MonadIO,
+    liftIO,
+ )
+
+-- DearImGui
+import DearImGui (
+    DrawData (..),
+ )
+import Foreign.Ptr
+import SDL (SDLRenderer (SDLRenderer), SDLWindow (SDLWindow))
+
+C.context (Cpp.cppCtx <> C.bsCtx)
+C.include "imgui.h"
+C.include "backends/imgui_impl_sdlrenderer3.h"
+C.include "backends/imgui_impl_sdl3.h"
+C.include "SDL3/SDL.h"
+Cpp.using "namespace ImGui"
+
+-- | Wraps @ImGui_ImplSDL3_InitForSDLRenderer@.
+sdl3InitForSDLRenderer :: (MonadIO m) => SDLWindow -> SDLRenderer -> m Bool
+sdl3InitForSDLRenderer (SDLWindow windowPtr) (SDLRenderer renderPtr) = liftIO do
+    let windowPtr' = castPtr windowPtr :: Ptr ()
+        renderPtr' = castPtr renderPtr :: Ptr ()
+    (0 /=) <$> [C.exp| bool { ImGui_ImplSDL3_InitForSDLRenderer((SDL_Window*)$(void* windowPtr'), (SDL_Renderer*)$(void* renderPtr')) } |]
+
+-- | Wraps @ImGui_ImplSDLRenderer3_Init@.
+sdl3RendererInit :: (MonadIO m) => SDLRenderer -> m Bool
+sdl3RendererInit (SDLRenderer renderPtr) = liftIO do
+    let renderPtr' = castPtr renderPtr :: Ptr ()
+    (0 /=) <$> [C.exp| bool { ImGui_ImplSDLRenderer3_Init((SDL_Renderer*)$(void* renderPtr')) } |]
+
+-- | Wraps @ImGui_ImplSDLRenderer3_Shutdown@.
+sdl3RendererShutdown :: (MonadIO m) => m ()
+sdl3RendererShutdown = liftIO do
+    [C.exp| void { ImGui_ImplSDLRenderer3_Shutdown(); } |]
+
+-- | Wraps @ImGui_ImplSDLRenderer3_NewFrame@.
+sdl3RendererNewFrame :: (MonadIO m) => m ()
+sdl3RendererNewFrame = liftIO do
+    [C.exp| void { ImGui_ImplSDLRenderer3_NewFrame(); } |]
+
+-- | Wraps @ImGui_ImplSDLRenderer3_RenderDrawData@.
+sdl3RendererRenderDrawData :: (MonadIO m) => SDLRenderer -> DrawData -> m ()
+sdl3RendererRenderDrawData (SDLRenderer renderPtr) (DrawData ptr) = liftIO do
+    let renderPtr' = castPtr renderPtr :: Ptr ()
+    [C.exp| void { ImGui_ImplSDLRenderer3_RenderDrawData((ImDrawData*) $( void* ptr ), (SDL_Renderer*) $( void* renderPtr' )) } |]

--- a/src/DearImGui/SDL3/Renderer.hs
+++ b/src/DearImGui/SDL3/Renderer.hs
@@ -43,7 +43,7 @@ import DearImGui (
     DrawData (..),
  )
 import Foreign.Ptr
-import SDL (SDLRenderer (SDLRenderer), SDLWindow (SDLWindow))
+import SDL3 (SDLRenderer (SDLRenderer), SDLWindow (SDLWindow))
 
 C.context (Cpp.cppCtx <> C.bsCtx)
 C.include "imgui.h"


### PR DESCRIPTION
I've made integration of sdl3 renderer. For sdl3 i've used the bindings by https://github.com/klukaszek/sdl3-hs
Demo window works with [this renderer example](https://github.com/klukaszek/sdl3-hs/blob/main/examples/RenderExample.hs).

<img width="912" height="740" alt="Screenshot 2025-11-18 at 13 54 56" src="https://github.com/user-attachments/assets/0da52dd6-0489-454c-8747-8218f1daa8a2" />

It's totally not ready for merge, since the sdl3 bindings uses same namespace as sdl2 package. So the some cabal flag gymnastics is needed, which is looking ugly. 
I'm totally need your advices how to make this more acceptable.