### PR TITLE
Add config flags api

### DIFF
--- a/src/DearImGui.hs
+++ b/src/DearImGui.hs
@@ -29,6 +29,11 @@ module DearImGui
   , Raw.DrawData(..)
   , Raw.getDrawData
   , Raw.checkVersion
+ 
+    -- * Configuration
+  , enableKeyboardNav 
+  , disableKeyboardNav
+  , isKeyboardNavEnabled
 
     -- * Demo, Debug, Information
   , Raw.showDemoWindow
@@ -457,6 +462,7 @@ import Control.Monad
 import Data.Bool
 import Data.Foldable
   ( foldl', for_, traverse_ )
+import Data.Bits ((.&.))
 import Foreign
 import Foreign.C
 
@@ -495,6 +501,23 @@ import qualified Data.Vector.Unboxed as VU
 getVersion :: MonadIO m => m Text
 getVersion = liftIO do
   Raw.getVersion >>= Text.peekCString
+
+-- | Enable keyboard navigation
+enableKeyboardNav :: MonadIO m => m ()
+enableKeyboardNav = 
+  Raw.addConfigFlags Raw.ImGuiConfigFlags_NavEnableKeyboard
+
+-- | Disable keyboard navigation
+disableKeyboardNav :: MonadIO m => m ()
+disableKeyboardNav = 
+  Raw.removeConfigFlags Raw.ImGuiConfigFlags_NavEnableKeyboard
+
+-- | Check if keyboard navigation is enabled
+isKeyboardNavEnabled :: MonadIO m => m Bool
+isKeyboardNavEnabled = liftIO do
+  Raw.ImGuiConfigFlags flags <- Raw.getConfigFlags
+  let Raw.ImGuiConfigFlags navFlag = Raw.ImGuiConfigFlags_NavEnableKeyboard
+  pure $ (flags .&. navFlag) /= 0
 
 -- | Send text to logs.
 logText :: MonadIO m => Text -> m ()

--- a/src/DearImGui/Raw.hs
+++ b/src/DearImGui/Raw.hs
@@ -32,6 +32,12 @@ module DearImGui.Raw
   , getDrawData
   , checkVersion
 
+    -- ** Configuration
+  , getConfigFlags
+  , setConfigFlags
+  , addConfigFlags
+  , removeConfigFlags
+
     -- * Demo, Debug, Information
   , showDemoWindow
   , showMetricsWindow
@@ -449,6 +455,27 @@ getDrawData = liftIO do
 checkVersion :: (MonadIO m) => m ()
 checkVersion = liftIO do
   [C.exp| void { IMGUI_CHECKVERSION(); } |]
+
+
+-- | Get the current ImGuiIO ConfigFlags
+getConfigFlags :: MonadIO m => m ImGuiConfigFlags
+getConfigFlags = liftIO do
+  [C.exp| ImGuiConfigFlags { GetIO().ConfigFlags } |]
+
+-- | Set the ImGuiIO ConfigFlags
+setConfigFlags :: MonadIO m => ImGuiConfigFlags -> m ()
+setConfigFlags flags = liftIO do
+  [C.block| void { GetIO().ConfigFlags = $(ImGuiConfigFlags flags); } |]
+
+-- | Modify ConfigFlags by OR-ing with additional flags
+addConfigFlags :: MonadIO m => ImGuiConfigFlags -> m ()
+addConfigFlags flags = liftIO do
+  [C.block| void { GetIO().ConfigFlags |= $(ImGuiConfigFlags flags); } |]
+
+-- | Remove flags from ConfigFlags
+removeConfigFlags :: MonadIO m => ImGuiConfigFlags -> m ()
+removeConfigFlags flags = liftIO do
+  [C.block| void { GetIO().ConfigFlags &= ~$(ImGuiConfigFlags flags); } |]
 
 
 -- | Create demo window. Demonstrate most ImGui features. Call this to learn


### PR DESCRIPTION
Adds functions to get and modify ImGuiIO ConfigFlags at runtime, enabling 
control over keyboard navigation, gamepad support, and other global ImGui 
configuration options.

## Changes

### Raw API (`DearImGui.Raw`)
- `getConfigFlags :: m ImGuiConfigFlags` - Get current flags
- `setConfigFlags :: ImGuiConfigFlags -> m ()` - Set flags directly
- `addConfigFlags :: ImGuiConfigFlags -> m ()` - OR in additional flags
- `removeConfigFlags :: ImGuiConfigFlags -> m ()` - Clear specific flags

## Example Usage
```haskell
-- Enable keyboard navigation
ImGui.addConfigFlags ImGui.ImGuiConfigFlags_NavEnableKeyboard

-- Disable mouse input
ImGui.addConfigFlags ImGui.ImGuiConfigFlags_NoMouse

-- Remove a flag
ImGui.removeConfigFlags ImGui.ImGuiConfigFlags_NavEnableKeyboard

-- Check current flags
flags <- ImGui.getConfigFlags
```

This allows runtime configuration of ImGui behavior that was previously 
only accessible through direct C++ IO structure manipulation.